### PR TITLE
Improve Makefile and setup workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,25 +15,23 @@ Medical images are captured under inconsistent conditions — different cameras,
 ## Setup
 
 ```bash
-pip install -r requirements.txt
+make venv     # Creates venv and installs dependencies (recommended on macOS)
+# or
+make install  # Install dependencies directly
 ```
 
 ## Usage
 
-### Local
+### Training Workflow
+
+Models are trained on NVIDIA RTX 4070 Ti Super.
 
 ```bash
-make install   # Install dependencies
-make data      # Download HAM10000 dataset
-make train     # Run training
-make evaluate  # Run evaluation
-```
-
-### Model Management
-
-```bash
-make upload-model MODEL=results/models/classifier.pt TAG=v1.0.0    # Upload to GitHub release
-make download-model TAG=v1.0.0 OUTPUT=results/models/classifier.pt # Download from release
+make install                                                        # Install dependencies
+make data                                                           # Download HAM10000 dataset
+make train                                                          # Train model
+make evaluate                                                       # Evaluate performance
+make upload-model MODEL=results/models/classifier.pt TAG=v1.0.0    # Upload trained model
 ```
 
 ### GitHub Actions


### PR DESCRIPTION
## Summary
- Streamline development setup with venv support
- Consolidate Makefile for better maintainability
- Fix macOS threading issues

## Changes

### Setup Improvements
- New `make venv` target creates virtual environment with Homebrew Python 3.11
- Auto-detects and uses venv if available, falls back to system Python
- Updated README with recommended setup workflow

### Makefile Consolidation
- Added `PYTHON` and `PYTHON_ENV` variables to eliminate repetition
- All Python commands now use consistent interpreter and environment
- Threading environment variables (`OMP_NUM_THREADS`, `MKL_NUM_THREADS`) prevent macOS mutex errors
- Removed unused `download-model` target

### Documentation
- Updated README Setup section with `make venv` recommendation
- Documented NVIDIA RTX 4070 Ti Super training workflow
- Simplified training workflow with model upload step

🤖 Generated with [Claude Code](https://claude.com/claude-code)