### PR TITLE
Configure webapp for GitHub Pages deployment with external API

### DIFF
--- a/.github/workflows/deploy-webapp.yml
+++ b/.github/workflows/deploy-webapp.yml
@@ -1,0 +1,62 @@
+name: Deploy Webapp to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'app/skintag-webapp/**'
+      - '.github/workflows/deploy-webapp.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: app/skintag-webapp
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: 'app/skintag-webapp/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build Next.js app
+        env:
+          NEXT_PUBLIC_API_URL: ${{ secrets.API_URL }}
+        run: npm run build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './app/skintag-webapp/out'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/NGROK.md
+++ b/NGROK.md
@@ -1,0 +1,41 @@
+# ngrok Remote Access
+
+Expose the inference server from your NVIDIA GPU machine to the internet via HTTPS tunnel.
+
+## Setup
+
+1. **Create ngrok account**
+   - Visit https://ngrok.com/signup
+   - Sign up for free account
+
+2. **Install ngrok**
+   ```bash
+   brew install ngrok
+   ```
+
+3. **Authenticate**
+   - Get authtoken from https://dashboard.ngrok.com/get-started/your-authtoken
+   - Run: `ngrok config add-authtoken YOUR_TOKEN`
+
+## Usage
+
+**Start server with public HTTPS URL:**
+```bash
+make app-remote
+```
+
+The terminal displays the public URL (e.g., `https://abc123.ngrok.io`)
+
+**Stop server:**
+```bash
+make stop
+```
+
+## Local Access
+
+For local-only testing:
+```bash
+make app
+```
+
+Server runs at http://localhost:8000

--- a/app/skintag-webapp/.env.example
+++ b/app/skintag-webapp/.env.example
@@ -1,0 +1,2 @@
+# API endpoint for inference server
+NEXT_PUBLIC_API_URL=https://your-inference-api.com

--- a/app/skintag-webapp/README.md
+++ b/app/skintag-webapp/README.md
@@ -1,36 +1,90 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# SkinTag WebApp
 
-## Getting Started
+Modern web interface for SkinTag skin lesion triage system.
 
-First, run the development server:
+## Features
+
+- Camera capture and file upload
+- Real-time analysis via external API
+- Risk score visualization
+- Condition probability estimates
+- Mobile-optimized design with Framer Motion animations
+
+## Setup
+
+### Local Development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Create `.env.local` file:
+   ```bash
+   cp .env.example .env.local
+   ```
+
+3. Set your API endpoint in `.env.local`:
+   ```
+   NEXT_PUBLIC_API_URL=http://localhost:8000
+   ```
+
+4. Run development server:
+   ```bash
+   npm run dev
+   ```
+
+   Open [http://localhost:3000](http://localhost:3000)
+
+### Build for Production
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm run build
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Static files will be output to the `out/` directory.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## GitHub Pages Deployment
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+The app is configured to deploy automatically to GitHub Pages when changes are pushed to `main`.
 
-## Learn More
+### Configuration
 
-To learn more about Next.js, take a look at the following resources:
+1. **Repository Settings**: Enable GitHub Pages in repository settings
+   - Source: GitHub Actions
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+2. **API URL Secret**: Add your inference API URL
+   - Go to Settings → Secrets and variables → Actions
+   - Add secret: `API_URL` with your inference server URL
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+3. **Push to Deploy**: Workflow triggers automatically on push to `main`
 
-## Deploy on Vercel
+### Manual Deployment
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+Trigger deployment manually:
+- Go to Actions → Deploy Webapp to GitHub Pages → Run workflow
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+## Architecture
+
+```
+User Browser → GitHub Pages (Static) → External API Server → ML Model
+```
+
+- **Frontend**: Next.js static export hosted on GitHub Pages
+- **Backend**: Separate inference API (FastAPI) with no authentication
+- **Model**: Downloaded from GitHub Releases by backend
+
+## Environment Variables
+
+| Variable | Description | Required |
+|----------|-------------|----------|
+| `NEXT_PUBLIC_API_URL` | Inference API endpoint | Yes |
+
+## Tech Stack
+
+- Next.js 16
+- React 19
+- TypeScript
+- Tailwind CSS 4
+- Framer Motion
+- Lucide Icons

--- a/app/skintag-webapp/next.config.ts
+++ b/app/skintag-webapp/next.config.ts
@@ -1,7 +1,11 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  output: 'export',
+  basePath: '/SkinTag',
+  images: {
+    unoptimized: true,
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
Configure Next.js webapp for GitHub Pages deployment with external inference API.

## Changes
- **API Integration**: Replace simulated inference with real API calls
- **TypeScript Updates**: Update interfaces to match backend response format  
- **Static Export**: Configure Next.js for static site generation (`output: 'export'`)
- **GitHub Actions**: Add workflow for automatic deployment on push to main
- **Environment Config**: Add `.env.example` for API URL configuration
- **Documentation**: Update README with setup and deployment instructions

## Architecture
```
GitHub Pages (Static) → External API Server → ML Model
```

Frontend is fully static and hosted on GitHub Pages, while inference runs on a separate API server that downloads models from GitHub Releases.

## Deployment Steps
1. Enable GitHub Pages (Settings → Pages → Source: GitHub Actions)
2. Add `API_URL` secret (Settings → Secrets → Actions)
3. Merge this PR - workflow will auto-deploy

## Testing
- [ ] Local development with `npm run dev`
- [ ] Build succeeds with `npm run build`
- [ ] API integration works with external endpoint

Closes #15